### PR TITLE
Updated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ TODO
 *.zip
 node_modules
 build
+.tscache
 tscommand.tmp.txt

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "regex-search",
   "version": "0.1.0",
   "devDependencies": {
-    "grunt": "~0.4.2",
+    "grunt": "~0.4.4",
     "grunt-contrib-copy": "~0.5.0",
-    "grunt-ts": "~1.5.1",
+    "grunt-ts": "~1.11.2",
     "grunt-contrib-compress": "^0.8.0"
   }
 }


### PR DESCRIPTION
Note: Executing `grunt` does output some info log messages from `grunt-ts`.

> Fast compile will not work when --out is specified. Ignoring fast compilation

This is, as far as I know, not something to worry about.
