### PR TITLE
Key shortcuts

### DIFF
--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -78,6 +78,10 @@ module Popup {
                 } else {
                     search(id, tabStates);
                 }
+            } else if (event.keyCode == 27) {
+                Log.info("Esc pressed");
+                setSearching(id, false, tabStates);
+                Utils.sendCommand("clear");
             }
         }
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -69,7 +69,15 @@ module Popup {
         var queryInputKeyDown = function(event) {
             if (event.keyCode == 13) {
                 Log.info("Enter pressed");
-                search(id, tabStates);
+                if (tabStates.isSearching(id)) {
+                    if (event.shiftKey) {
+                        prevButtonClick();
+                    } else {
+                        nextButtonClick();
+                    }
+                } else {
+                    search(id, tabStates);
+                }
             }
         }
 


### PR DESCRIPTION
This pull request allows enter and shift+enter to move to the next and previous results, respectively. Pressing escape from within the search input will also clear the matches box and highlights.